### PR TITLE
Do not re-compress camera image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -106,7 +106,6 @@ RUN apt update && \
 	ros-humble-rmw-cyclonedds-cpp \
 	ros-humble-diagnostic-updater \
 	ros-humble-tf-transformations \
-	ros-humble-cv-bridge \
 	&& \
 	apt clean && \
 	rm -rf /var/lib/apt/lists/*

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,4 @@ Flask
 python-socketio
 simple-websocket
 bleak
-numpy==1.26.4
 transforms3d==0.4.2


### PR DESCRIPTION
We decided not to recompress the already compressed images, but to use them as is.

I have already confirmed that it works fine with Gazebo images, but please test it on the actual Cabot machine and merge it into main if it is OK.