### PR TITLE
Remove camera image interval / Add camera_image_request

### DIFF
--- a/common.py
+++ b/common.py
@@ -127,14 +127,6 @@ def send_touch():
         handler.handleTouchCallback(message)
 
 @util.setInterval(1)
-def send_camera_image():
-    global last_camera_image
-    image, last_camera_image = last_camera_image, None
-    if image is not None:
-        for handler in event_handlers:
-            handler.handleCameraImageCallback(image)
-
-@util.setInterval(1)
 def send_location():
     global last_location
     location, last_location = last_location, None
@@ -143,7 +135,6 @@ def send_location():
             handler.handleLocationCallback(location)
 
 send_touch()
-send_camera_image()
 send_location()
 
 class BLESubChar:
@@ -423,16 +414,13 @@ class CabotLogResponseChar(BLENotifyChar):
 
 
 class CameraImageChars(BLENotifyChar):
-    def __init__(self, owner, uuid, interval=5):
+    def __init__(self, owner, uuid):
         super().__init__(owner, None)
         self.uuid = uuid
-        self.interval = interval
-        self.count = 0
 
-    def handleLCameraImageCallback(self, msg):
-        self.count += 1
-        if self.interval <= self.count:
-            self.count = 0
+    def sendCameraImage(self, msg=None):
+        msg = msg or last_camera_image
+        if msg:
             m = re.search(r" (.*) compressed", msg.format)
             self.send_text(self.uuid, f"data:image/{m and m[1] or 'jpg'};base64,{base64.b64encode(msg.data).decode()}")
 

--- a/common.py
+++ b/common.py
@@ -297,8 +297,8 @@ class BLENotifyChar:
         self.owner = owner
         self.uuid = uuid
 
-    def send_text(self, uuid, text, priority=10, to=None):
-        self.owner.send_text(uuid, text, priority, to=to)
+    def send_text(self, uuid, text, priority=10, to=None, skip_sid=None):
+        self.owner.send_text(uuid, text, priority, to=to, skip_sid=skip_sid)
 
 
 class VersionChar(BLENotifyChar):

--- a/common.py
+++ b/common.py
@@ -297,8 +297,8 @@ class BLENotifyChar:
         self.owner = owner
         self.uuid = uuid
 
-    def send_text(self, uuid, text, priority=10):
-        self.owner.send_text(uuid, text, priority)
+    def send_text(self, uuid, text, priority=10, to=None):
+        self.owner.send_text(uuid, text, priority, to=to)
 
 
 class VersionChar(BLENotifyChar):
@@ -418,11 +418,11 @@ class CameraImageChars(BLENotifyChar):
         super().__init__(owner, None)
         self.uuid = uuid
 
-    def sendCameraImage(self, msg=None):
+    def sendCameraImage(self, msg=None, to=None):
         msg = msg or last_camera_image
         if msg:
             m = re.search(r" (.*) compressed", msg.format)
-            self.send_text(self.uuid, f"data:image/{m and m[1] or 'jpg'};base64,{base64.b64encode(msg.data).decode()}")
+            self.send_text(self.uuid, f"data:image/{m and m[1] or 'jpg'};base64,{base64.b64encode(msg.data).decode()}", to=to)
 
 
 class LocationChars(BLENotifyChar):

--- a/tcp.py
+++ b/tcp.py
@@ -103,7 +103,7 @@ class CaBotTCP():
             @self.sio.event
             def share(sid, data):
                 common.logger.info(f"share {data[0]}")
-                self.sio.emit("share", data[0])
+                self.sio.emit("share", data[0], skip_sid=sid)
 
             @self.sio.event
             def camera_image_request(sid, data):
@@ -135,8 +135,8 @@ class CaBotTCP():
 
         self.error_count = 0
 
-    def send_text(self, uuid, text, priority=10, to=None):
-        self.sio.emit(uuid, text, to=to)
+    def send_text(self, uuid, text, priority=10, to=None, skip_sid=None):
+        self.sio.emit(uuid, text, to=to, skip_sid=skip_sid)
 
     def handleSpeak(self, req, res):
         common.logger.info("/speak request tcp (%s)", str(req))

--- a/tcp.py
+++ b/tcp.py
@@ -105,6 +105,11 @@ class CaBotTCP():
                 common.logger.info(f"share {data[0]}")
                 self.sio.emit("share", data[0])
 
+            @self.sio.event
+            def camera_image_request(sid, data):
+                common.logger.info(f"camera_image_request {data}")
+                self.camera_image_char.sendCameraImage()
+
 
         self.version_char = common.VersionChar(self, "cabot_version")
 
@@ -115,7 +120,7 @@ class CaBotTCP():
         self.speak_char = common.SpeakChar(self, "speak")
         self.event_char = common.EventChars(self, "navigate")
         self.touch_char = common.TouchChars(self, "touch")
-        self.camera_image_char = common.CameraImageChars(self, "camera_image", interval=3)
+        self.camera_image_char = common.CameraImageChars(self, "camera_image")
         self.location_char = common.LocationChars(self, "location")
 
         self.handler = subchar_handler("/cabot")
@@ -145,9 +150,6 @@ class CaBotTCP():
 
     def handleTouchCallback(self, msg):
         self.touch_char.handleTouchCallback(msg)
-
-    def handleCameraImageCallback(self, msg):
-        self.camera_image_char.handleLCameraImageCallback(msg)
 
     def handleLocationCallback(self, msg):
         self.location_char.handleLocationCallback(msg)

--- a/tcp.py
+++ b/tcp.py
@@ -108,7 +108,7 @@ class CaBotTCP():
             @self.sio.event
             def camera_image_request(sid, data):
                 common.logger.info(f"camera_image_request {data}")
-                self.camera_image_char.sendCameraImage()
+                self.camera_image_char.sendCameraImage(to=sid)
 
 
         self.version_char = common.VersionChar(self, "cabot_version")
@@ -135,8 +135,8 @@ class CaBotTCP():
 
         self.error_count = 0
 
-    def send_text(self, uuid, text, priority=10):
-        self.sio.emit(uuid, text)
+    def send_text(self, uuid, text, priority=10, to=None):
+        self.sio.emit(uuid, text, to=to)
 
     def handleSpeak(self, req, res):
         common.logger.info("/speak request tcp (%s)", str(req))

--- a/test/index.html
+++ b/test/index.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script src="https://cdn.socket.io/4.8.1/socket.io.min.js"></script>
-    <script src="index.js"></script>
     <title>Socket.io test</title>
 </head>
 <body>
@@ -21,5 +20,6 @@
     <pre id="system_status"></pre>
     <h3>Device Status</h3>
     <pre id="device_status"></pre>
+    <script src="index.js"></script>
 </body>
 </html>

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,7 @@
 const sio = io("http://localhost:5000");
 
+window.setInterval(() => sio.emit("camera_image_request", []), 1000);
+
 sio.on("connect", () => {
     console.log("connected");
 });


### PR DESCRIPTION
To save network bandwidth, image transfers triggered by the interval timer have been removed.
Instead, transfers can be requested using the camera_image_request event.