### PR TITLE
fix bug of bake-docker.sh, built tag name does not match with the tag in docker-compose.yaml

### DIFF
--- a/bake-docker.sh
+++ b/bake-docker.sh
@@ -119,9 +119,9 @@ if [[ -z $tags ]]; then
     tags="latest,$(git rev-parse --abbrev-ref HEAD | tr '/' '-')"
 fi
 if [[ "$tags" == *,* ]]; then
-    tag_option="--set=${service}.tags=${REGISTRY}/cabot-${service}:{$tags}"
+    tag_option="--set=${service}.tags=${REGISTRY}/${service}:{$tags}"
 else
-    tag_option="--set=${service}.tags=${REGISTRY}/cabot-${service}:$tags"
+    tag_option="--set=${service}.tags=${REGISTRY}/${service}:$tags"
 fi
 
 # platform option


### PR DESCRIPTION
This pull request fixed the bag that bake-docker.sh create image "cmucal/cabot-cabot-app-server" instead of "cmucal/cabot-app-server" in dockerhub.

DCO 1.1 Signed-off-by: Tatsuya Ishihara <tisihara@jp.ibm.com>