### PR TITLE
Log socket.io disconnect with reason for problem analysis

### DIFF
--- a/cabot_app_server/scripts/tcp.py
+++ b/cabot_app_server/scripts/tcp.py
@@ -118,6 +118,10 @@ class CaBotTCP():
                 self.camera_image_char.sendCameraImage(to=sid)
                 self.camera_orientation_char.sendCameraOrientation(to=sid)
 
+            @self.sio.event
+            def disconnect(sid, reason):
+                common.logger.info(f"disconnect socket.io {reason=}")
+
 
         self.version_char = common.VersionChar(self, "cabot_version")
         self.name_char = common.NameChar(self, "cabot_name")


### PR DESCRIPTION
socket.io connect is logged, but disconnect is not.
This is inconvenient, so I added disconnect logging for problem analysis.