### PR TITLE
clean up ros_entrypoint.sh for supporting the command with double quotes in docker compose files

### DIFF
--- a/docker/ros2/ros_entrypoint.sh
+++ b/docker/ros2/ros_entrypoint.sh
@@ -35,6 +35,4 @@ fi
 
 export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$HOST_UID/bus
 
-WORKDIR=$(pwd)
-
-exec gosu developer bash -c "cd $WORKDIR && exec $*"
+exec gosu developer "$@"


### PR DESCRIPTION

DCO 1.1 Signed-off-by: Tatsuya Ishihara <tisihara@jp.ibm.com>