### PR TITLE
do not copy people_msgs in Dockerfile because it is already included in docker image

### DIFF
--- a/docker/ros2/Dockerfile
+++ b/docker/ros2/Dockerfile
@@ -20,11 +20,10 @@ RUN cd /tmp && \
 	cd /opt/custom_ws && \
 	cp -r /tmp/cabot-navigation/cabot-common/cabot_msgs src && \
 	cp -r /tmp/cabot-navigation/cabot-common/cabot_common src && \
-	cp -r /tmp/cabot-navigation/cabot-common/docker/humble-custom/people/people_msgs src && \
 	cp -r /tmp/cabot-navigation/cabot src && \
 	cp -r /tmp/cabot-navigation/cabot_ui src && \
 	cp -r /tmp/cabot-navigation/mf_localization_msgs src && \
-	. /opt/ros/humble/setup.sh && \
+	. /opt/custom_ws/install/setup.sh && \
 	colcon build
 
 FROM ${FROM_IMAGE} AS build


### PR DESCRIPTION
This pull request fixed docker image build error after cabot-base is separated from cabot-common.
Because people_msgs is already included in docker image, I removed the line to copy people_msgs in Dockerfile.

DCO 1.1 Signed-off-by: Tatsuya Ishihara <tisihara@jp.ibm.com>