### PR TITLE
Itohtaka/release emergency stop

### DIFF
--- a/cabot_app_server/scripts/cabot_app.py
+++ b/cabot_app_server/scripts/cabot_app.py
@@ -335,12 +335,12 @@ class CaBotManager():
         self._call(["sudo", "systemctl", "reboot"], lock=self.systemctl_lock)
 
     def poweroffPC(self):
-        if shutdown_client.wait_for_service(timeout_sec=1.0):
+        if shutdown_client.wait_for_service(timeout_sec=5.0):
             req = Trigger.Request()
             shutdown_client.call(req)
 
     def releaseEmergencystop(self, release=True):
-        if set_24v_power_odrive_client.wait_for_service(timeout_sec=1.0):
+        if set_24v_power_odrive_client.wait_for_service(timeout_sec=5.0):
             req = SetBool.Request()
             req.data = release
             set_24v_power_odrive_client.call(req)

--- a/cabot_app_server/scripts/cabot_app.py
+++ b/cabot_app_server/scripts/cabot_app.py
@@ -339,10 +339,10 @@ class CaBotManager():
             req = Trigger.Request()
             shutdown_client.call(req)
 
-    def releaseEmergencystop(self):
+    def releaseEmergencystop(self, release=True):
         if set_24v_power_odrive_client.wait_for_service(timeout_sec=1.0):
             req = SetBool.Request()
-            req.data = True
+            req.data = release
             set_24v_power_odrive_client.call(req)
 
     def startCaBot(self):

--- a/cabot_app_server/scripts/cabot_app.py
+++ b/cabot_app_server/scripts/cabot_app.py
@@ -41,7 +41,7 @@ import tcp
 from cabot_common import util
 from cabot_log_report import LogReport
 from cabot_msgs.srv import Speak
-from std_srvs.srv import Trigger
+from std_srvs.srv import Trigger, SetBool
 import sensor_msgs.msg
 
 MTU_SIZE = 2**10  # could be 2**15, but 2**10 is enough
@@ -339,6 +339,12 @@ class CaBotManager():
             req = Trigger.Request()
             shutdown_client.call(req)
 
+    def releaseEmergencystop(self):
+        if set_24v_power_odrive_client.wait_for_service(timeout_sec=1.0):
+            req = SetBool.Request()
+            req.data = True
+            set_24v_power_odrive_client.call(req)
+
     def startCaBot(self):
         self._call(["systemctl", "--user", "start", "cabot"], lock=self.systemctl_lock)
         self._cabot_system_status.activating()
@@ -474,6 +480,7 @@ async def main():
     global ble_manager
     global quit_flag
     global shutdown_client
+    global set_24v_power_odrive_client
 
     def handleSpeak(req, res):
         res.result = False
@@ -488,6 +495,7 @@ async def main():
     common.cabot_node_common.create_service(Speak, '/speak', handleSpeak)
     common.cabot_node_common.create_subscription(sensor_msgs.msg.BatteryState, '/battery_state', cabot_manager.battery_state, 10)
     shutdown_client = common.cabot_node_common.create_client(Trigger, "/shutdown")
+    set_24v_power_odrive_client = common.cabot_node_common.create_client(SetBool, "/set_24v_power_odrive")
 
     global tcp_server_thread
     try:

--- a/cabot_app_server/scripts/cabot_app.py
+++ b/cabot_app_server/scripts/cabot_app.py
@@ -344,6 +344,8 @@ class CaBotManager():
             req = SetBool.Request()
             req.data = release
             set_24v_power_odrive_client.call(req)
+        else:
+            common.logger.error(f"timeout /set_24v_power_odrive service")
 
     def startCaBot(self):
         self._call(["systemctl", "--user", "start", "cabot"], lock=self.systemctl_lock)

--- a/cabot_app_server/scripts/common.py
+++ b/cabot_app_server/scripts/common.py
@@ -214,6 +214,8 @@ class CabotManageChar(BLESubChar):
             self.manager.enableWiFi(True)
         if value == "disablewifi":
             self.manager.enableWiFi(False)
+        if value == "release_emergencystop":
+            self.manager.releaseEmergencystop()
         if value.startswith("lang"):
             lang = value[5:]
             event = NavigationEvent(subtype="language", param=lang)


### PR DESCRIPTION
- https://github.com/CMU-cabot/TODO-Consortium/issues/859


Tested with simulator
```log
power_controller-prod-1  | [INFO] [launch]: All log files can be found below /home/developer/.ros/log/2025-04-27-23-01-38-497301-LEGION-Y540-1
power_controller-prod-1  | [INFO] [launch]: Default logging verbosity is set to INFO
power_controller-prod-1  | [INFO] [launch.user]: Launching for model: cabot3-k4
power_controller-prod-1  | [INFO] [launch.user]:             use_ace: False
power_controller-prod-1  | [INFO] [launch.user]:              use_kx: True
power_controller-prod-1  | [INFO] [power_controller-1]: process started with pid [81]
power_controller-prod-1  | [power_controller-1] [INFO] [1745794898.617078671] [power_controller]: Success open CAN can0 (10)
power_controller-prod-1  | [power_controller-1] [WARN] [1745794948.044941984] [power_controller]: turn on 24V_odrive
power_controller-prod-1  | [power_controller-1] [WARN] [1745794948.045470448] [power_controller]: send data
```